### PR TITLE
ListAllBeerStylesUseCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Teste solicitado pela empresa Be Growth.
 
 ## Funcionalidades
 
-- [ ] CRUD de estilos de cerveja (criar, editar, excluir, listar e importar via CSV)
+- [ ] CRUD de estilos de cerveja (criar, listar, editar, excluir e importar via CSV)
 - [ ] Retornar a cerveja ideal junto com uma playlist do Spotify, dada a temperatura
 - [ ] Se houver mais de uma cerveja retornada, classificar por ordem alfabética
 - [ ] Se não houver playlist do Spotify o status 204 na playlist

--- a/src/modules/beerStyles/infra/typeorm/repositories/BeerStylesRepository.ts
+++ b/src/modules/beerStyles/infra/typeorm/repositories/BeerStylesRepository.ts
@@ -12,7 +12,7 @@ class BeerStylesRepository implements IBeerStyleRepository {
     this.ormRepository = getRepository(BeerStyle);
   }
 
-  async find(): Promise<BeerStyle[]> {
+  async findAll(name?: string): Promise<BeerStyle[]> {
     throw new Error("Method not implemented.");
   }
 

--- a/src/modules/beerStyles/infra/typeorm/repositories/BeerStylesRepository.ts
+++ b/src/modules/beerStyles/infra/typeorm/repositories/BeerStylesRepository.ts
@@ -27,7 +27,7 @@ class BeerStylesRepository implements IBeerStyleRepository {
   async findByName(name: string): Promise<BeerStyle> {
     const beerStyle = await this.ormRepository.findOne({
       where: {
-        name: Raw((alias) => `LOWER(${alias}) Like '%${name.toLowerCase()}%'`),
+        name: Raw((alias) => `LOWER(${alias}) = '${name.toLowerCase()}'`),
       },
     });
 

--- a/src/modules/beerStyles/infra/typeorm/repositories/BeerStylesRepository.ts
+++ b/src/modules/beerStyles/infra/typeorm/repositories/BeerStylesRepository.ts
@@ -12,8 +12,12 @@ class BeerStylesRepository implements IBeerStyleRepository {
     this.ormRepository = getRepository(BeerStyle);
   }
 
-  async findAll(name?: string): Promise<BeerStyle[]> {
-    throw new Error("Method not implemented.");
+  async findAll(name = ""): Promise<BeerStyle[]> {
+    return this.ormRepository.find({
+      where: {
+        name: Raw((alias) => `LOWER(${alias}) Like '%${name.toLowerCase()}%'`),
+      },
+    });
   }
 
   async findByID(id: string): Promise<BeerStyle> {

--- a/src/modules/beerStyles/repositories/IBeerStylesRepository.ts
+++ b/src/modules/beerStyles/repositories/IBeerStylesRepository.ts
@@ -3,7 +3,7 @@ import { IUpdateBeerStyleDTO } from "../dtos/IUpdateBeerStyleDTO";
 import { BeerStyle } from "../infra/typeorm/entities/BeerStyle";
 
 interface IBeerStyleRepository {
-  find(): Promise<BeerStyle[]>;
+  findAll(name?: string): Promise<BeerStyle[]>;
   findByID(id: string): Promise<BeerStyle>;
   findByName(name: string): Promise<BeerStyle>;
   filterByTemperatureRange(temperature: string): Promise<BeerStyle[]>;

--- a/src/modules/beerStyles/repositories/fakes/FakeBeerStylesRepository.ts
+++ b/src/modules/beerStyles/repositories/fakes/FakeBeerStylesRepository.ts
@@ -7,8 +7,8 @@ import { IBeerStyleRepository } from "../IBeerStylesRepository";
 class FakeBeerStylesRepository implements IBeerStyleRepository {
   private beerStyles: BeerStyle[] = [];
 
-  async find(): Promise<BeerStyle[]> {
-    throw new Error("Method not implemented.");
+  async findAll(name?: string): Promise<BeerStyle[]> {
+    return this.beerStyles;
   }
 
   async findByID(id: string): Promise<BeerStyle> {

--- a/src/modules/beerStyles/repositories/fakes/FakeBeerStylesRepository.ts
+++ b/src/modules/beerStyles/repositories/fakes/FakeBeerStylesRepository.ts
@@ -8,7 +8,9 @@ class FakeBeerStylesRepository implements IBeerStyleRepository {
   private beerStyles: BeerStyle[] = [];
 
   async findAll(name?: string): Promise<BeerStyle[]> {
-    return this.beerStyles;
+    return this.beerStyles.filter((beerStyle) =>
+      beerStyle.name.toLowerCase().includes(name.toLowerCase())
+    );
   }
 
   async findByID(id: string): Promise<BeerStyle> {

--- a/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.spec.ts
+++ b/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.spec.ts
@@ -1,0 +1,39 @@
+import { FakeBeerStylesRepository } from "@modules/beerStyles/repositories/fakes/FakeBeerStylesRepository";
+
+import { ListAllBeerStylesUseCase } from "./ListAllBeerStylesUseCase";
+
+let listAllBeerStylesUseCase: ListAllBeerStylesUseCase;
+let fakeBeerStylesRepository: FakeBeerStylesRepository;
+
+describe("List All Beer Styles", () => {
+  beforeEach(() => {
+    fakeBeerStylesRepository = new FakeBeerStylesRepository();
+    listAllBeerStylesUseCase = new ListAllBeerStylesUseCase(
+      fakeBeerStylesRepository
+    );
+  });
+
+  it("should be able to list all beer styles without filter", async () => {
+    await fakeBeerStylesRepository.create({
+      name: "a beer style name 1",
+      minimum_temperature: -5,
+      maximum_temperature: 5,
+    });
+
+    await fakeBeerStylesRepository.create({
+      name: "a beer style name 2",
+      minimum_temperature: -5,
+      maximum_temperature: 5,
+    });
+
+    await fakeBeerStylesRepository.create({
+      name: "a beer style name 3",
+      minimum_temperature: -5,
+      maximum_temperature: 5,
+    });
+
+    const beerStyles = await listAllBeerStylesUseCase.execute({});
+
+    expect(beerStyles.length).toBe(3);
+  });
+});

--- a/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.spec.ts
+++ b/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.spec.ts
@@ -62,4 +62,10 @@ describe("List All Beer Styles", () => {
 
     expect(beerStyles.length).toBe(1);
   });
+
+  it("should return an empty array if there isn't a beer style to show", async () => {
+    const beerStyles = await listAllBeerStylesUseCase.execute({});
+
+    expect(beerStyles).toEqual([]);
+  });
 });

--- a/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.spec.ts
+++ b/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.spec.ts
@@ -37,7 +37,7 @@ describe("List All Beer Styles", () => {
     expect(beerStyles.length).toBe(3);
   });
 
-  it("should be able to list all beer styles with filter by na,e", async () => {
+  it("should be able to list all beer styles filtering by name", async () => {
     await fakeBeerStylesRepository.create({
       name: "filtered beer style 1",
       minimum_temperature: -5,

--- a/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.spec.ts
+++ b/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.spec.ts
@@ -36,4 +36,30 @@ describe("List All Beer Styles", () => {
 
     expect(beerStyles.length).toBe(3);
   });
+
+  it("should be able to list all beer styles with filter by na,e", async () => {
+    await fakeBeerStylesRepository.create({
+      name: "filtered beer style 1",
+      minimum_temperature: -5,
+      maximum_temperature: 5,
+    });
+
+    await fakeBeerStylesRepository.create({
+      name: "a beer style name 2",
+      minimum_temperature: -5,
+      maximum_temperature: 5,
+    });
+
+    await fakeBeerStylesRepository.create({
+      name: "a beer style name 3",
+      minimum_temperature: -5,
+      maximum_temperature: 5,
+    });
+
+    const beerStyles = await listAllBeerStylesUseCase.execute({
+      name: "filtered",
+    });
+
+    expect(beerStyles.length).toBe(1);
+  });
 });

--- a/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.ts
+++ b/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.ts
@@ -13,7 +13,7 @@ class ListAllBeerStylesUseCase {
   ) {}
 
   async execute({ name = "" }: IRequest) {
-    throw new Error("Method not implemented.");
+    return this.beerStylesRepository.findAll(name);
   }
 }
 

--- a/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.ts
+++ b/src/modules/beerStyles/useCases/listAllBeerStyles/ListAllBeerStylesUseCase.ts
@@ -1,0 +1,20 @@
+import { IBeerStyleRepository } from "@modules/beerStyles/repositories/IBeerStylesRepository";
+import { inject, injectable } from "tsyringe";
+
+interface IRequest {
+  name?: string;
+}
+
+@injectable()
+class ListAllBeerStylesUseCase {
+  constructor(
+    @inject("BeerStylesRepository")
+    private beerStylesRepository: IBeerStyleRepository
+  ) {}
+
+  async execute({ name = "" }: IRequest) {
+    throw new Error("Method not implemented.");
+  }
+}
+
+export { ListAllBeerStylesUseCase };


### PR DESCRIPTION
Add:
* [x] ListAllBeerStylesUseCase (with test)

Implements:
* [x] Should be able to list all beer styles without filter
* [x] Should be able to list all beer styles filtering by name
* [x] Should return an empty array if there isn't a beer style to show

Fix:
* [x] Replace 'like' operator to 'equal' operator in findByName raw query at BeerStylesRepository